### PR TITLE
Enable Live Preview

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,14 @@
+{
+  "landingPage": "\/wp-admin\/options-general.php#change-from-address",
+  "preferredVersions": {
+    "php": "8.2",
+    "wp": "latest"
+  },
+  "steps": [
+    {
+      "step": "login",
+      "username": "admin",
+      "password": "password"
+    }
+  ]
+}


### PR DESCRIPTION
Adding a blueprint.json to enable live previews in the WP.org Plugin Directory