### PR TITLE
Fix Playground landing page anchor

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,5 +1,5 @@
 {
-  "landingPage": "\/wp-admin\/options-general.php#change-from-address",
+  "landingPage": "\/wp-admin\/options-general.php#email-from-address",
   "preferredVersions": {
     "php": "8.2",
     "wp": "latest"


### PR DESCRIPTION
## Summary
- `blueprint.json` pointed to `#change-from-address`, but the plugin emits its settings section as `<span id="email-from-address">` (and uses that same anchor in its own action link). Playground wasn't reliably scrolling to the section on load.
- Updated the blueprint anchor to match.

## Test plan
- [ ] Open the Playground link from `.wordpress-org/blueprints/blueprint.json` and confirm it lands on the "Site Email From Address" section under Settings → General.

🤖 Generated with [Claude Code](https://claude.com/claude-code)