### PR TITLE
Bump Tested up to 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Contributors: obenland
 Tags: email, sender, branding, communication, identity
 Requires at least: 4.3
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 3
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
WordPress 7.0 is the latest stable release.

Bumps `Tested up to` in README.md from 6.9 to 7.0 (major.minor of 7.0).